### PR TITLE
Add ForTrilinos and use Fortran-enabled SWIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following table lists the packages contained in this release of E4S.
 | faodel          | 1.1906.1  | data+viz  |
 | flecsi          | 1         | math      |
 | flit            | 2.1.0     | dev tools |
+| fortrilinos     | 2.0.0     | math      |
 | gasnet          | 2020.3.0  | pmr core  |
 | ginkgo          | 1.3.0     | math      |
 | globalarrays    | 5.7       |           |
@@ -80,7 +81,7 @@ The following table lists the packages contained in this release of E4S.
 | sundials        | 5.4.0     | math      |
 | superlu         | 5.2.1     | math      |
 | superlu-dist    | 6.3.1     | math      |
-| swig            | 4.0.2     | math      |
+| swig            | 4.0.2-f   |           |
 | sz              | 2.1.10    | data+viz  |
 | tasmanian       | 7.3       | math      |
 | tau             | 2.29.1    | dev tools |

--- a/spack.yaml
+++ b/spack.yaml
@@ -121,6 +121,7 @@ spack:
   - faodel@1.1906.1
   - flecsi@1 +cinch
   - flit@2.1.0
+  - fortrilinos@2.0.0
   - gasnet@2020.3.0
   - ginkgo@1.3.0
   - globalarrays@5.7
@@ -164,7 +165,7 @@ spack:
   - sundials@5.4.0
   - superlu-dist@6.3.1
   - superlu@5.2.1
-  - swig@4.0.2
+  - swig@4.0.2-fortran
   - sz@2.1.10
   - tasmanian@7.3
   - tau@2.29.1


### PR DESCRIPTION
ForTrilinos, which used to be bundled as part of Trilinos but is now an independent spack recipe. ForTrilinos is advertised as being part of E4S but the new `fortrilinos` package hasn't been added to the spec list.

Also, the version of SWIG in E4S isn't the Fortran-enabled one that was developed through ECP (through the math libraries group, even though it's really a dev tool of sorts used for helping out the math libs). This PR updates the version to `4.0.2-fortran`.