### PR TITLE
Enable all named trilinos packages by default

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -283,7 +283,7 @@ spack:
     - tasmanian@7.5
     - tau@2.30.1
     - trilinos@13.0.1
-    - trilinos@13.0.1 +nox +superlu-dist
+    - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +teuchos +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist
     - turbine@1.3.0
     - umap@2.1.0
     - umpire@4.1.2

--- a/spack.yaml
+++ b/spack.yaml
@@ -222,7 +222,7 @@ spack:
     - faodel@1.1906.1
     - flecsi@1.4 +cinch
     - flit@2.1.0
-    - fortrilinos@2.0.0 ^trilinos +nox +superlu-dist +stratimikos
+    - fortrilinos@2.0.0
     - gasnet@2021.3.0
     - ginkgo@1.3.0
     - globalarrays@5.8
@@ -282,8 +282,7 @@ spack:
     - sz@2.1.11.1
     - tasmanian@7.5
     - tau@2.30.1
-    - trilinos@13.0.1
-    - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +teuchos +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist
+    - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +teuchos +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long
     - turbine@1.3.0
     - umap@2.1.0
     - umpire@4.1.2


### PR DESCRIPTION
The ExaSMR ECP app requires
```
+amesos +amesos2 +anasazi +aztec +belos +ifpack +teuchos
gotype=long_long +epetra +epetraext +kokkos +ifpack2 +intrepid +ml
+sacado +shards +tpetra +stratimikos +hdf5 +mpi
```
when linking against an externally installed trilinos.  Not all Trilinos packages are enabled by default on Spack, and we might soon be disabling even more of them by default. Since E4S is usually distributed as a binary package, prefer to provide all packages that clients *might* need. (The alternative is that apps see "Trilinos" support but end up having to compile their own version because of a missing package.)

We might  have to iterate on this as building more packages increases the chance of incompatibilities with a particular  platform.