### PR TITLE
sphinx based readthedocs build for E4S docs

### DIFF
--- a/.github/workflows/urlcheck.yml
+++ b/.github/workflows/urlcheck.yml
@@ -15,7 +15,7 @@ jobs:
         # clone devel
         branch: main
         # A comma-separated list of file types to cover in the URL checks
-        file_types: .md
+        file_types: .md,.rst
 
         # Choose whether to include file with no URLs in the prints.
         print_all: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.yml
+
+version: 2
+
+sphinx:
+    builder: html
+    configuration: docs/conf.py
+
+build:
+  image: latest
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'E4S'
+copyright = '2021, Mike Heroux, Sameer Shende'
+author = 'Mike Heroux, Sameer Shende'
+
+# The full version, including alpha/beta/rc tags
+release = '21.05'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,6 +1,101 @@
 Contributing Guide
 ====================
 
+
+User Contribution Guide
+-------------------------
+
+Contribution is not easy, so we created this document to describe how to get you setup
+so you can contribute back and make everyone's life easier. All contributions will be made via
+`pull request <https://github.com/E4S-Project/e4s/pulls>`_ which goes through review
+process. We have disabled push to main branch, therefore all changes must go through pull request.
+
+You must have a GitHub account to contribute back, if you don't have one please
+`register <http://github.com/join>`_ to create your account.
+
+Default Branch
+~~~~~~~~~~~~~~~~
+
+The default branch is `master <https://github.com/E4S-Project/e4s/tree/master>`_. This branch
+is protected to ensure no-one accidently deletes this branch. All PRs are sent to `master` branch.
+
+Setup
+~~~~~~~
+
+Assuming you have forked the repo, you will want to clone your fork repo::
+
+    git clone git@github.com:YOUR\_GITHUB\_LOGIN/e4s.git
+
+You might need to setup your SSH keys in your git profile if you are using ssh option for cloning. For more details on
+setting up SSH keys in your profile, follow instruction found in
+https://help.github.com/articles/connecting-to-github-with-ssh/
+
+SSH key will help you pull and push to repository without requesting for password for every commit. Once you have forked the
+repo, clone your local repo
+
+Next let's navigate to the directory and add the ``upstream`` repo endpoint as follows::
+
+    cd e4s
+    git remote add upstream git@github.com:E4S-Project/e4s.git
+
+
+The ``upstream`` tag is used to sync your local fork with upstream repo.
+
+Make sure you set your user name and email set properly in git configuration.
+We don't want commits from unknown users. This can be done by setting the following::
+
+    git config user.name "First Last"
+    git config user.email "abc@example.com"
+
+
+For more details see this article `Getting Started - First Time Git Setup. <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_
+
+
+Sync your branch from upstream
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``master`` from upstream will get Pull Requests from other contributors, in-order
+to sync your forked repo with upstream, you must sync your local ``master`` branch and push
+changes to your fork. This can be done by running the following commands::
+
+    git checkout master
+    git fetch upstream master
+    git pull upstream master
+
+Once the changes are pulled locally you can push your changes to your fork by running::
+
+    git push origin main
+
+
+Feature Branch
+~~~~~~~~~~~~~~~~
+
+Please make sure to create a new branch when adding and new feature. Do not
+push to ``master`` branch on your fork or upstream.
+
+Create a new feature branch from ``master`` as follows::
+
+    git checkout master
+    git checkout -b <BRANCHNAME>
+
+
+Now you are ready to make any changes to your feature branch, once you are ready
+you can commit and push your changes to your fork. This can be done as follows::
+
+    git add <file1> <file2> <dir1> <dir2>
+    git commit -m <COMMIT_MESSAGE>
+    git push origin <BRANCHNAME>
+
+Once the branch is created in your fork, you can issue a Pull Request to ``master``
+branch for ``upstream`` repo (https://github.com/E4S-Project/e4s).
+
+Please check the `CI actions <https://github.com/E4S-Project/e4s/actions>`_ reported in your pull request and make sure they
+pass. The `urlchecker workflow <https://github.com/E4S-Project/e4s/blob/master/.github/workflows/urlcheck.yml>`_
+is responsible for checking urls, this is using github action `urlstechie/urlchecker-action <https://github.com/urlstechie/urlchecker-action>`_.
+If the CI check reports a failure on url that is valid please exclude the url in the check. For more details on urlchecker-action see
+the `documentation <https://github.com/urlstechie/urlchecker-action/blob/master/README.md>`_.
+
+
 ReadTheDocs Integration
 ------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,64 @@
+Contributing Guide
+====================
+
+ReadTheDocs Integration
+------------------------
+
+The E4S project is built via `readthedocs <https://readthedocs.org>`_ platform and the project is hosted at
+https://readthedocs.org/projects/e4s/. If you need access to readthedocs project please contact `wspear <https://github.com/wspear>`_
+or `shahzebsiddiqui <https://github.com/shahzebsiddiqui>`_. You must create an account at https://readthedocs.org/accounts/signup/ in
+order to gain access.
+
+We have enabled a `webhook integration <https://docs.readthedocs.io/en/stable/webhooks.html>`_ between readthedocs and Github project
+(https://github.com/E4S-Project/e4s) so that incoming Pull Request are built on the platform. In addition, we have enabled
+`Pull Request Builds <https://docs.readthedocs.io/en/stable/pull-requests.html>`_ so one can see the rendered documentation
+before merging to main branch.
+
+Building Docs Locally
+-----------------------
+
+If you want to build the user docs locally, please have a python 3.x environment and install the dependencies via ``pip`` as follows::
+
+    pip install -r docs/requirements.txt
+
+Next, you should navigate to the ``docs`` directory and build the docs as follows::
+
+    cd docs
+    make html
+
+Shown below is a preview of the documentation build if done correctly
+
+.. code-block:: console
+
+    (e4s) bash-3.2$ make html
+    Running Sphinx v4.1.2
+    loading pickled environment... done
+    building [mo]: targets for 0 po files that are out of date
+    building [html]: targets for 1 source files that are out of date
+    updating environment: 0 added, 1 changed, 0 removed
+    reading sources... [100%] contributing
+    looking for now-outdated files... none found
+    pickling environment... done
+    checking consistency... done
+    preparing documents... done
+    writing output... [100%] index
+    generating indices... genindex done
+    writing additional pages... search done
+    copying images... [100%] ../logos/E4S-dark-green.png
+    copying static files... done
+    copying extra files... done
+    dumping search index in English (code: en)... done
+    dumping object inventory... done
+    build succeeded.
+
+    The HTML pages are in _build/html.
+
+The documentation is built via `sphinx <https://www.sphinx-doc.org/en/master/>`_ via the Makefile which
+will generate the html pages under ``_build/html`` directory. You can view the docs locally by opening
+the page in your browser or run the following::
+
+    open _build/html/index.html
+
+The `.readthedocs.yml <https://github.com/E4S-Project/e4s/blob/master/.readthedocs.yml>`_ configuration file is responsible
+for configuring readthedocs setting during documentation build. This file can be found in the root of the repo. For more details
+please see https://docs.readthedocs.io/en/stable/config-file/v2.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,26 @@
+.. E4S documentation master file, created by
+   sphinx-quickstart on Mon Aug 23 15:24:44 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+.. image:: ../logos/E4S-dark-green.png
+   :width: 120
+
+Welcome to E4S's documentation!
+===============================
+
+.. toctree::
+   :maxdepth: 2
+
+   introduction.rst
+   policy.rst
+   spack.rst
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,12 +9,22 @@
 Welcome to E4S's documentation!
 ===============================
 
+
+| |docs| |license|
+
+.. |docs| image:: https://readthedocs.org/projects/e4s/badge/?version=latest
+    :alt: Documentation Status
+    :target: https://e4s.readthedocs.io/en/latest/?badge=latest
+
+.. |license| image:: https://img.shields.io/github/license/E4S-Project/e4s.svg
+
 .. toctree::
    :maxdepth: 2
 
    introduction.rst
    policy.rst
    spack.rst
+   contributing.rst
 
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,67 @@
+Introduction
+==============
+
+The Extreme-scale Scientific Software Stack (E4S) is a community effort to
+provide open source software packages for developing, deploying and running
+scientific applications on high-performance computing (HPC) platforms.
+E4S provides from-source builds and containers of a broad collection of HPC software packages.
+
+Purpose
+--------
+
+E4S exists to accelerate the development, deployment and use of HPC software, lowering the barriers for HPC users. E4S provides containers and turn-key,
+from-source builds of more than 80 popular HPC products in programming models, such as MPI; development tools such as HPCToolkit, TAU and PAPI;
+math libraries such as PETSc and Trilinos; and Data and Viz tools such as HDF5 and Paraview.
+
+Interoperability Approach
+--------------------------
+
+
+While porting of individual scientific software products is challenging, achieving interoperability between packages is even more difficult.
+E4S uses a dual-pronged approach for achieving software interoperability: Spack and SDKs.
+
+`Spack <https://spack.readthedocs.io/en/latest/>`_: E4S uses the Spack packages manager for software delivery. Spack provides the ability to specify versions of software packages that are and are not interoperable.
+It is also a common build layer to not only E4S software, but also an enormous number of software packages outside of ECP ST. These features support achieving and maintaining interoperability between ST software packages.
+
+`Software Development Kits (SDKs) <https://xsdk.info/>`_: An ECP ST Software Development Kit is a collection of related ECP ST software products (called packages) where coordination across package teams will improve usability and practices,
+and foster community growth among teams that develop similar and complementary capabilities. An SDK is more of a project than a product, although it involves several products. It can also be considered as an association of products and product teams.
+The activities that take place inside an SDK promote interoperability (where appropriate and logical) between products. The initial version 0.2 release of E4S contains member packages of one SDK - the Extreme-Scale Scientific Software Development Kit (xSDK).
+Future releases will incorporate additional SDKs that will be defined in the coming months.
+
+
+
+Distribution
+------------
+
+E4S is open source software published under the `MIT License <https://github.com/E4S-Project/e4s/blob/master/LICENSE>`_. E4S can be redistributed and
+modified under the terms of this license. E4S packages each have their own open source license.
+
+Contacts
+---------
+
+.. csv-table::
+    :header: "Name", "Title", "Email"
+    :widths:  30, 30, 30
+
+    "Michael A. Heroux", "Project Leader", "maherou@sandia.gov"
+    "Sameer Shende", "E4S Lead", "sameer@cs.uoregon.edu"
+    "James Willenbring", "SDK Lead", "jmwille@sandia.gov"
+
+References
+-----------
+
+.. csv-table::
+    :header: "Conference", "Date", "Link"
+    :widths:  60, 30, 30
+
+     "Getting Started with E4S for Industry and Agencies Workshop", "June, 2021", "`E4S-IAW21 <https://www.exascaleproject.org/event/e4sforindustry/>`_"
+     "E4S: Extreme-Scale Scientific Software Stack", "June, 2021", "`BSSW <https://bssw.io/blog_posts/e4s-extreme-scale-scientific-software-stack>`_"
+     "E4S Tutorial at ECP Annual Meeting", "April, 2021", "`Video <https://youtu.be/vGKgAXtSFu0>`_"
+     "E4S BoF at ECP Annual Meeting", "April, 2021", "`Video <https://youtu.be/5UbIUxYKb6o>`_"
+     "State of E4S - July 2020 Update", "July 2020", "`PPTX <https://e4s-project.github.io/E4S_July20.pptx>`_"
+     "ECP Software Technology Capability Assessment Report (CAR) Version 1.5", "Feb, 2019", "`PDF <https://www.exascaleproject.org/wp-content/uploads/2019/02/ECP-ST-CAR.pdf>`_"
+     "DOE’S E4S Software Stack Takes An Extreme Step Towards Exascale", "Jan, 2019", "`Article <https://www.nextplatform.com/2019/01/22/does-e4s-software-stack-takes-an-extreme-step-towards-exascale/>`_"
+     "Extreme-Scale Scientific Software Stack (E4S) Release 0.1", "Nov, 2018", "`Video <https://www.youtube.com/watch?v=nfCXwX_0EBc>`_"
+
+
+

--- a/docs/policy.rst
+++ b/docs/policy.rst
@@ -1,0 +1,59 @@
+E4S Community Policy
+=====================
+
+E4S Member Policy
+-----------------
+
+The policies below are criteria for E4S membership. To qualify for E4S membership, a package must demonstrate compatibility with each of these policies. Under special circumstances, a package may be granted an exception to a policy.
+
+- **P1** *Spack-based Build and Installation* Each E4S member package supports a scriptable `Spack <https://spack.io/>`_ build and production-quality installation in a way that is compatible with other E4S member packages in the same environment. When E4S build, test, or installation issues arise, there is an expectation that teams will collaboratively resolve those issues.
+
+- **P2** *Minimal Validation* Testing Each E4S member package has at least one test that is executable through the E4S validation test suite (https://github.com/E4S-Project/testsuite). This will be a post-installation test that validates the usability of the package. The E4S validation test suite provides basic confidence that a user can compile, install and run every E4S member package. The E4S team can actively participate in the addition of new packages to the suite upon request.
+
+- **P3** *Sustainability* All E4S compatibility changes will be sustainable in that the changes go into the regular development and release versions of the package and should not be in a private release/branch that is provided only for E4S releases.
+
+- **P4** *Documentation* Each E4S member package should have sufficient documentation to support installation and use.
+
+- **P5** *Product Metadata* Each E4S member package team will provide key product information via metadata that is organized in the `E4S DocPortal <https://e4s-project.github.io/DocPortal.html>`_ format. Depending on the filenames where the metadata is located, this may require `minimal setup <https://github.com/E4S-Project/E4S-Documenter/blob/master/README.md>`_.
+
+- **P6** *Public Repository* Each E4S member package will have a public repository, for example at GitHub or Bitbucket, where the development version of the package is available and pull requests can be submitted.
+
+- **P7** *Imported Software* If an E4S member package imports software that is externally developed and maintained, then it must allow installing, building, and linking against a functionally equivalent outside copy of that software. Acceptable ways to accomplish this include (1) forsaking the internal copied version and using an externally-provided implementation or (2) changing the file names and namespaces of all global symbols to allow the internal copy and the external copy to coexist in the same downstream libraries and programs. This pertains primarily to third party support libraries and does not apply to key components of the package that may be independent packages but are also integral components to the package itself.
+
+- **P8** *Error Handling* Each E4S member package will adopt and document a consistent system for signifying error conditions as appropriate for the language and application. For e.g., returning an error condition or throwing an exception. In the case of a command line tool, it should return a sensible exit status on success/failure, so the package can be safely run from within a script.
+
+- **P9** *Test Suite* Each E4S member package will provide a test suite that does not require special system privileges or the purchase of commercial software. This test suite should grow in its comprehensiveness over time. That is, new and modified features should be included in the suite.
+
+Future Revision E4S Community Policies
+--------------------------------------
+
+The policies below are being considered for future revisions of the E4S Community Policies. These policies require further refinement or planning prior to adoption. The topics that these policies address provide information about likely subject areas for E4S policies going forward.
+
+Note: FP stands for “future policy”
+
+- **FP1** *Portability* Each E4S member package team will make a best effort at portability to common platforms. Depending on the function of the member package, considerations may include operating systems, compiler toolchains, architectures and accelerators. Lack of support for configurations should be denoted in appropriate Spack packages when possible.
+
+  including standard Linux distributions, common compiler toolchains, and different architectures and accelerators. Consider: self assessed portability score/metric - OS, GPU, etc?
+
+- **FP2** *Flexible Test Selection Support* Each E4S member package will support the ability to specify that specific tests will be run for a given system allocation limit on execution time and node configuration resources. Particular use cases include the ability to a) run a subset of the test suite to complete within a few hours on standard workstation-level hardware b) be runnable in batch-only environments, that is, systems that require the use of PBS or other submission scripts.
+
+- **FP3** *Dependency Version Tracking* Each E4S member package will document the versions of packages with which it can work or upon which it depends, in Spack. Similarly, incompatible versions of packages should also be appropriately tracked in Spack. The developers of E4S member packages will coordinate the needed versions of various packages for each E4S release.
+
+- **FP4** *Memory Testing* Each E4S member package makes it possible to run their test suite under Valgrind in order to test for memory corruption issues. NOTE: The SDK team is planning to refine this policy so as to not specifically single out Valgrind.
+
+- **FP5** *Comprehensive Test Suite* Each E4S member package will provide a comprehensive test suite that can be run by users and does not require special system privileges or the purchase of commercial software.
+
+- **FP6** *Documentation* Each E4S member package should have sufficient documentation to support installation, use, and further development, as assessed periodically by its community of peers.
+
+Library Policies: Apply to linkable libraries and similar products
+-------------------------------------------------------------------
+
+Note: FLP stands for “future library policy”
+
+- **FLP1** *User-managed Exception Handling* Each E4S member library package will have no hardwired calls to abort, exit, or MPI_Abort(). Also, no package should have hardwired print statements for error conditions. Each package should document which error codes/exceptions are recoverable, which may result in lost resources (for example, unfreed memory), and which indicate that the process may be in an undefined or totally broken state (for example, after a segmentation violation). It is the responsibility of the calling routine not to simply continue the computation when a “hard” error is returned; the calling routine will likely, by default, call an abort, but again that should be possible to override.
+
+- **FLP2** *User-managed I/O Control* No package should have hardwired print or I/O statements that cannot be turned off through a programmatic interface; output should never be hard-wired to stdout or stderr. It is recommended that packages provide a way for users to turn on output and allow them to direct where it goes. Also, packages may print to stdout by default but only on one process (i.e., root rank “0”). But packages may also be completely silent by default (and require that users turn on outputting in the appropriate way).
+
+- **FLP3** *Symbols and Namespacing* Each E4S member package will use a limited and well-defined symbol, macro, library, and include file name space. For example, there should be no publicly visible include files such as utils.h, or packages named libutil.a or macros named YES or TRUE. Namespacing of include files can be handled either by prepending each include file with a package name, for example <XXXmat.h>, or by placing and referencing all include files in a subdirectory with a package name, for example <XXX/mat.h>. Note that using a -I/XXX/ and referencing via <mat.h> would not be acceptable namespacing.
+
+- **FLP4** *Memory Leaks* Each E4S member package will free all system resources it has acquired as soon as they are no longer needed, including closing open files, freeing memory, freeing MPI communicators, and freeing MPI data types created by the package. In particular, it is important that E4S compatible code not have any growing memory leaks (such as leaking memory during every timestep). Any resources created by the package that should be freed by the user, rather than by the package, must be fully documented. Note: Exceptions are permitted for situations where other software quality considerations are more important.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 sphinx
 sphinx-rtd-theme
+# issue with rendering bullet points in sphinx docutils 0.17 or higher see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
+docutils==0.16

--- a/docs/spack.rst
+++ b/docs/spack.rst
@@ -1,6 +1,21 @@
 E4S Distribution via spack.yaml
 ================================
 
+21.08
+-------
+
+E4S 21.08 is based on Spack branch `e4s-21.08 <https://github.com/spack/spack/tree/e4s-21.08>`_. Shown
+below is the spack configuration from Univ of Oregon system. The specs are pushed to buildcache which
+can be retrieved using the following commands
+
+.. code-block:: console
+
+    $ spack mirror add E4S https://cache.e4s.io/21.08
+    $ spack buildcache keys -it
+
+.. literalinclude:: ../environments/21.08/spack.yaml
+    :language: yaml
+
 21.05
 ------
 

--- a/docs/spack.rst
+++ b/docs/spack.rst
@@ -1,0 +1,41 @@
+E4S Distribution via spack.yaml
+================================
+
+21.05
+------
+
+E4S 21.05 uses Spack branch `e4s-21.05 <https://github.com/spack/spack/tree/e4s-21.05>`_
+
+Spack Build Cache:
+
+- https://cache.e4s.io
+
+- https://cache.e4s.io/21.05
+
+.. literalinclude:: ../environments/21.05/spack.yaml
+   :language: yaml
+
+
+21.02
+------
+
+February 2021 release of E4S (21.02)
+
+E4S 21.02 is based on Spack tag `e4s-21.02 <https://github.com/spack/spack/releases/tag/e4s-21.02>`_
+
+.. literalinclude:: ../environments/21.02/spack.yaml
+   :language: yaml
+
+20.10
+------
+
+This is the October 2020 release of E4S (20.10)
+
+E4S 20.10 is based on Spack version `0.15.4-1620-e1e0bbb4c`
+
+- commit: `e1e0bbb4cbe11a3f0d7e50466ffa86071ee653b7 <https://github.com/spack/spack/commit/e1e0bbb4cbe11a3f0d7e50466ffa86071ee653b7>`_
+
+- `Thu Oct 22 15:05:18 2020 -0400`
+
+.. literalinclude:: ../environments/20.10/spack.yaml
+   :language: yaml

--- a/environments/21.08/spack.yaml
+++ b/environments/21.08/spack.yaml
@@ -5,177 +5,126 @@ spack:
 
   packages:
     all:
-      compiler:
-        - gcc@9.3.0
+      compiler: [gcc@9.3.0]
       providers:
-        blas:
-          - openblas
-        mpi:
-          - mpich
+        blas: [openblas]
+        mpi: [mpich]
       target:
         - x86_64
       variants: +mpi
     autoconf:
-      version:
-      - '2.69'
+      version: [2.69]
     automake:
-      version:
-      - 1.16.3
+      version: [1.16.3]
     berkeley-db:
-      version:
-      - 18.1.40
+      version: [18.1.40]
     binutils:
+      version: [2.36.1]
       variants: +ld +gold +headers +libiberty ~nls +plugins
-      version:
-      - 2.36.1
     boost:
-      version:
-      - 1.76.0
+      version: [1.76.0]
       variants: visibility=global
     bzip2:
-      version:
-      - 1.0.8
+      version: [1.0.8]
     c-blosc:
-      version:
-      - 1.21.0
+      version: [1.21.0]
     cmake:
-      version:
-      - 3.20.5
+      version: [3.20.5]
     curl:
-      version:
-      - 7.76.1
+      version: [7.76.1]
     diffutils:
-      version:
-      - 3.7
+      version: [3.7]
     doxygen:
-      version:
-      - 1.8.20
+      version: [1.8.20]
     elfutils:
-      version:
-      - 0.185
+      version: [0.185]
       variants: +bzip2 ~nls +xz
     expat:
-      version:
-      - 2.4.1
+      version: [2.4.1]
     fftw:
       variants: +openmp
     findutils:
-      version:
-      - 4.8.0
+      version: [4.8.0]
     gdbm:
-      version:
-      - 1.19
+      version: [1.19]
     gettext:
-      version:
-      - 0.21
+      version: [0.21]
     git:
-      version:
-      - 2.31.1
+      version: [2.31.1]
     glib:
-      version:
-      - 2.68.2
+      version: [2.68.2]
     hdf5:
+      version: [1.12.0]
       variants: +fortran +hl +shared api=v18
-      version:
-      - 1.12.0
     help2man:
-      version:
-      - 1.47.16
+      version: [1.47.16]
     hwloc:
-      version:
-      - 2.4.1
+      version: [2.4.1]
     json-c:
-      version:
-      - 0.15
+      version: [0.15]
     libbsd:
-      version:
-      - 0.11.3
+      version: [0.11.3]
     libfabric:
-      version:
-      - 1.12.1
+      version: [1.12.1]
       variants: fabrics=sockets,tcp,udp,rxm
     libiconv:
-      version:
-      - 1.16
+      version: [1.16]
     libsigsegv:
-      version:
-      - 2.13
+      version: [2.13]
     libpciaccess:
-      version:
-      - 0.16
+      version: [0.16]
     libtool:
-      version:
-      - 2.4.6
+      version: [2.4.6]
     libunwind:
-      version:
-      - 1.5.0
+      version: [1.5.0]
       variants: +pic +xz
     libxml2:
-      version:
-      - 2.9.10
+      version: [2.9.10]
     lz4:
-      version:
-      - 1.9.3
+      version: [1.9.3]
     m4:
-      version:
-      - 1.4.19
+      version: [1.4.19]
     mesa:
       variants: ~llvm
     mesa18:
       variants: ~llvm
     mpich:
+      version: [3.4.2]
       variants: ~wrapperrpath
-      version:
-      - 3.4.2
     ncurses:
-      version:
-      - 6.2
+      version: [6.2]
       variants: +termlib
     numactl:
-      version:
-      - 2.0.14
+      version: [2.0.14]
     openblas:
-      version:
-      - 0.3.17
+      version: [0.3.17]
       variants: threads=openmp
     openssl:
-      version:
-        - 1.1.1k
+      version: [1.1.1k]
     perl:
-      version:
-      - 5.34.0
+      version: [5.34.0]
     pkgconf:
-      version:
-      - 1.7.4
+      version: [1.7.4]
     python:
-      version:
-      - 3.8.10
+      version: [3.8.10]
     readline:
-      version:
-      - 8.1
+      version: [8.1]
     sqlite:
-      version:
-      - 3.35.5
+      version: [3.35.5]
     tar:
-      version:
-      - 1.34
+      version: [1.34]
     trilinos:
-      version:
-      - 13.0.1
+      version: [13.0.1]
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     texinfo:
-      version:
-      - 6.5
+      version: [6.5]
     xz:
-      version:
-      - 5.2.5
+      version: [5.2.5]
       variants: +pic
     zlib:
-      version:
-      - 1.2.11
+      version: [1.2.11]
     zstd:
-      version:
-      - 1.5.0
+      version: [1.5.0]
 
   compilers:
   - compiler:


### PR DESCRIPTION
@maherou @sameershende @eugeneswalker @wspear 

This is an initial attempt for readthedocs build of E4S docs. Take a look at the PR docs build: https://e4s--25.org.readthedocs.build/en/25/ .

I have started to extract some of the docs from https://e4s-project.github.io into readthedocs so now you can write docs in .rst instead of html anchors. Let me know your thoughts on this and content that should be copied over. I foresee we can build the prototype before we switch over. 
