### PR TITLE
create dependabot for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # check weekly on Sunday at 1am UTC
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "01:00"
+    labels:
+      - "github-action dependencies"
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    # check weekly at 2am UTC
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "02:00"
+    labels:
+      - "pip dependencies"


### PR DESCRIPTION
This PR will enable [dependabot](https://dependabot.com/) to manage dependencies for github action and pip dependencies. For more details see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates 

This PR will check for github action in https://github.com/E4S-Project/e4s/tree/master/.github/workflows and pip dependency which will be provided in #25 once this is merged. This check will be done weekly