### PR TITLE
add url field in e4s support

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -16,6 +16,14 @@ body:
       required: true
       
   - type: input
+    id: url
+    attributes:
+      label: URL for Software
+      description: Please specify URL for software product
+    validations:
+      required: false
+      
+  - type: input
     id: contact
     attributes:
       label: Contact Details


### PR DESCRIPTION
@rmadamson 
You can see the rendered template in https://github.com/E4S-Project/e4s/blob/e4s_support/.github/ISSUE_TEMPLATE/support.yml 
