### PR TITLE
update deployment: document Crusher deployment 

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,14 +1,14 @@
 E4S Deployments
 ===============
 
+These deployments are maintained by `ParaTools <https://www.paratools.com/>`_ and may not be officially supported by facility staff.
+
 JLSE
 ----------
 
 **ParaTools Deployment: E4S 22.05**
 
 For more information on JLSE please see https://www.jlse.anl.gov.
-
-This deployment is maintained by `ParaTools <https://www.paratools.com/>`_ and may not be officially supported by facility staff.
 
 This deployment is built using Spack at branch `e4s-22.05` and system-provided OneAPI and MPI.
 
@@ -43,6 +43,159 @@ This deployment is built using Spack at branch `e4s-22.05` and system-provided O
     hypre/2.24.0-oneapi-2022.1.0-mpi           pumi/2.2.7-oneapi-2022.1.0-mpi              zfp/0.5.5-oneapi-2022.1.0
 
 
+Crusher
+----------
+
+**ParaTools Deployment: E4S 22.05 / PrgEnv-gnu**
+
+This deployment is built using Spack at branch `e4s-22.05` and the following facility-provided external packages:
+
+* PrgEnv-gnu
+* gcc/11.2.0
+* cray-mpich
+* ROCm 5.1.0
+
+The exact Spack environment used to build this configuration is available here:
+
+* /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-gnu/spack.yaml
+
+.. code-block:: console
+
+    $crusher> . /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-gnu/module-use.sh
+    $crusher> module avail
+        ------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-gnu/spack/share/spack/lmod/cray-sles15-x86_64/cray-mpich/8.1.16-u3ebvcw/Core -------------------------------
+       adios/1.13.1                   dyninst/12.1.0        (D)    lammps/20220107        (D)    parallel-netcdf/1.12.2 (D)    py-warpx/22.05-dimsRZ   (D)    tau/2.31.1-rocm
+       adios2/2.8.0                   exaworks/0.1.0               libquo/1.3.1           (D)    paraview/5.10.1               slate/2021.05.02        (D)    tau/2.31.1          (D)
+       amrex/22.05-rocm               faodel/1.2108.1       (D)    mercury/2.1.0          (D)    parsec/3.0.2012        (D)    slepc/3.17.1-rocm              trilinos/13.0.1
+       amrex/22.05             (D)    flecsi/1.4.2          (D)    metall/0.20            (D)    petsc/3.17.1-rocm             slepc/3.17.1            (D)    turbine/1.3.0       (D)
+       arborx/1.2-rocm                fortrilinos/2.0.0     (D)    mfem/4.4.0-rocm               petsc/3.17.1           (D)    stc/0.9.0                      unifyfs/0.9.2
+       arborx/1.2              (D)    globalarrays/5.8      (D)    mfem/4.4.0             (D)    phist/1.9.5                   strumpack/6.3.1-rocm           upcxx/2022.3.0-rocm
+       axom/0.6.1              (D)    hdf5/1.10.7                  mpifileutils/0.11.1    (D)    precice/2.4.0          (D)    strumpack/6.3.1         (D)    upcxx/2022.3.0      (D)
+       butterflypack/2.1.1     (D)    heffte/2.2.0-rocm            nccmp/1.9.0.1          (D)    pumi/2.2.7             (D)    sundials/6.2.0-rocm            veloc/1.5           (D)
+       cabana/0.4.0            (D)    heffte/2.2.0          (D)    nco/5.0.1              (D)    py-cinemasci/1.7.0            sundials/6.2.0          (D)
+       caliper/2.7.0           (D)    hpctoolkit/2022.04.15 (D)    netlib-scalapack/2.2.0 (D)    py-libensemble/0.9.1          superlu-dist/7.2.0-rocm
+       conduit/0.8.3                  hpx/1.7.1-rocm               omega-h/9.34.1         (D)    py-petsc4py/3.17.1            superlu-dist/7.2.0      (D)
+       darshan-runtime/3.3.1   (D)    hpx/1.7.1             (D)    openpmd-api/0.14.4     (D)    py-warpx/22.05-dims2          tasmanian/7.7-rocm
+       datatransferkit/3.1-rc3 (D)    hypre/2.24.0          (D)    papyrus/1.0.2          (D)    py-warpx/22.05-dims3          tasmanian/7.7           (D)
+
+    -------------------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-gnu/spack/share/spack/lmod/cray-sles15-x86_64/Core --------------------------------------------
+       aml/0.1.0       (D)    charliecloud/0.26             gasnet/2022.3.0       (D)    kokkos/3.6.00-rocm         nrm/0.1.0                  qthreads/1.16      (D)    sz/2.1.12         (D)
+       archer/2.0.0           cray-mpich/8.1.16    (L,D)    ginkgo/1.4.0-rocm            kokkos/3.6.00       (D)    openmpi/4.1.3              raja/0.14.0-rocm          umap/2.1.0        (D)
+       argobots/1.1    (D)    darshan-util/3.3.1   (D)      ginkgo/1.4.0          (D)    legion/21.03.0      (D)    papi/6.0.0.1               raja/0.14.0        (D)    umpire/6.0.0-rocm
+       bolt/2.0        (D)    flit/2.1.0           (D)      gmp/6.2.1             (D)    libunwind/1.6.2     (D)    pdt/3.25.1          (D)    superlu/5.3.0      (D)    umpire/6.0.0      (D)
+       chai/2.4.0-rocm        flux-core/0.38.0     (D)      gotcha/1.0.3          (D)    magma/2.6.2-rocm    (D)    plasma/21.8.29             swig/4.0.2-fortran        zfp/0.5.5         (D)
+       chai/2.4.0      (D)    gasnet/2022.3.0-rocm          kokkos-kernels/3.6.00 (D)    mpark-variant/1.4.0 (D)    py-jupyterhub/1.4.1        swig/4.0.2         (D)
+
+**ParaTools Deployment: E4S 22.05 / PrgEnv-amd**
+
+This deployment is built using Spack at branch `e4s-22.05` and the following facility-provided external packages:
+
+* PrgEnv-amd
+* amd/5.1.0
+* cray-mpich
+* ROCm 5.1.0
+
+The exact Spack environment used to build this configuration is available here:
+
+* /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-amd/spack.yaml
+
+.. code-block:: console
+
+    $crusher> . /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-amd/module-use.sh
+    $crusher> module avail
+        ------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-amd/spack/share/spack/lmod/cray-sles15-x86_64/cray-mpich/8.1.16-qhzn27v/Core -------------------------------
+       adios/1.13.1                   exaworks/0.1.0           hypre/2.24.0        (D)    nco/5.0.1              (D)    pumi/2.2.7           (D)    sundials/6.2.0          (D)    upcxx/2022.3.0-rocm
+       amrex/22.05-rocm               faodel/1.2108.1   (D)    lammps/20220107     (D)    netlib-scalapack/2.2.0 (D)    py-cinemasci/1.7.0          superlu-dist/7.2.0-rocm        upcxx/2022.3.0      (D)
+       amrex/22.05             (D)    fortrilinos/2.0.0 (D)    libquo/1.3.1        (D)    papyrus/1.0.2          (D)    py-libensemble/0.9.1        superlu-dist/7.2.0      (D)    veloc/1.5           (D)
+       arborx/1.2-rocm                globalarrays/5.8  (D)    mercury/2.1.0       (D)    parallel-netcdf/1.12.2 (D)    py-petsc4py/3.17.1          tasmanian/7.7-rocm             vtk-m/1.7.1         (D)
+       arborx/1.2              (D)    hdf5/1.10.7              metall/0.20         (D)    parsec/3.0.2012               rempi/1.1.0          (D)    tasmanian/7.7           (D)    wannier90/3.1.0
+       cabana/0.4.0            (D)    heffte/2.2.0-rocm        mfem/4.4.0-rocm            petsc/3.17.1-rocm             scr/3.0rc2                  tau/2.31.1-rocm
+       caliper/2.7.0                  heffte/2.2.0      (D)    mfem/4.4.0          (D)    petsc/3.17.1           (D)    slate/2021.05.02            tau/2.31.1              (D)
+       darshan-runtime/3.3.1          hpx/1.7.1-rocm           mpifileutils/0.11.1 (D)    plumed/2.6.3           (D)    stc/0.9.0                   trilinos/13.0.1         (D)
+       datatransferkit/3.1-rc3 (D)    hpx/1.7.1         (D)    nccmp/1.9.0.1       (D)    precice/2.4.0          (D)    sundials/6.2.0-rocm         turbine/1.3.0           (D)
+
+    -------------------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-amd/spack/share/spack/lmod/cray-sles15-x86_64/Core --------------------------------------------
+       aml/0.1.0         (D)    cray-mpich/8.1.16    (L,D)    ginkgo/1.4.0-rocm            kokkos/3.6.00       (D)    nrm/0.1.0                  raja/0.14.0-rocm          umap/2.1.0        (D)
+       argobots/1.1      (D)    darshan-util/3.3.1   (D)      ginkgo/1.4.0          (D)    legion/21.03.0      (D)    openmpi/4.1.3              raja/0.14.0        (D)    umpire/6.0.0-rocm
+       bolt/2.0          (D)    flit/2.1.0           (D)      gmp/6.2.1             (D)    libunwind/1.6.2     (D)    papi/6.0.0.1               superlu/5.3.0      (D)    umpire/6.0.0      (D)
+       chai/2.4.0-rocm          flux-core/0.38.0     (D)      gotcha/1.0.3          (D)    loki/0.1.7          (D)    pdt/3.25.1          (D)    swig/4.0.2-fortran        zfp/0.5.5         (D)
+       chai/2.4.0        (D)    gasnet/2022.3.0-rocm          kokkos-kernels/3.6.00 (D)    magma/2.6.2-rocm           py-jupyterhub/1.4.1        swig/4.0.2         (D)
+       charliecloud/0.26        gasnet/2022.3.0      (D)      kokkos/3.6.00-rocm           mpark-variant/1.4.0 (D)    qthreads/1.16       (D)    sz/2.1.12          (D)
+
+**ParaTools Deployment: E4S 22.05 / PrgEnv-cray**
+
+This deployment is built using Spack at branch `e4s-22.05` and the following facility-provided external packages:
+
+* PrgEnv-cray
+* cce/14.0.0
+* cray-mpich
+* ROCm 5.1.0
+
+The exact Spack environment used to build this configuration is available here:
+
+* /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-cray/spack.yaml
+
+.. code-block:: console
+
+    $crusher> . /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-cray/module-use.sh
+    $crusher> module avail
+        ------------------------------ /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-cray/spack/share/spack/lmod/cray-sles15-x86_64/cray-mpich/8.1.16-pq2h7mx/Core -------------------------------
+       adios/1.13.1            conduit/0.8.3           (D)    heffte/2.2.0-rocm        mfem/4.4.0-rocm               petsc/3.17.1-rocm           sundials/6.2.0-rocm            unifyfs/0.9.2
+       adios2/2.8.0     (D)    darshan-runtime/3.3.1   (D)    heffte/2.2.0      (D)    mfem/4.4.0             (D)    petsc/3.17.1         (D)    sundials/6.2.0          (D)    upcxx/2022.3.0-rocm
+       amrex/22.05-rocm        datatransferkit/3.1-rc3 (D)    hpx/1.7.1-rocm           mpifileutils/0.11.1    (D)    plumed/2.6.3         (D)    superlu-dist/7.2.0-rocm        upcxx/2022.3.0      (D)
+       amrex/22.05      (D)    faodel/1.2108.1         (D)    hpx/1.7.1         (D)    nccmp/1.9.0.1          (D)    precice/2.4.0        (D)    superlu-dist/7.2.0      (D)    veloc/1.5           (D)
+       arborx/1.2-rocm         flecsi/1.4.2            (D)    hypre/2.24.0      (D)    nco/5.0.1              (D)    pumi/2.2.7           (D)    tasmanian/7.7-rocm             vtk-m/1.7.1         (D)
+       arborx/1.2       (D)    fortrilinos/2.0.0       (D)    libquo/1.3.1      (D)    openpmd-api/0.14.4     (D)    py-libensemble/0.9.1        tasmanian/7.7           (D)
+       ascent/0.8.0     (D)    globalarrays/5.8               mercury/2.1.0     (D)    papyrus/1.0.2          (D)    py-petsc4py/3.17.1          trilinos/13.0.1         (D)
+       axom/0.6.1       (D)    hdf5/1.10.7                    metall/0.20       (D)    parallel-netcdf/1.12.2 (D)    stc/0.9.0                   turbine/1.3.0           (D)
+
+    ------------------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/PrgEnv-cray/spack/share/spack/lmod/cray-sles15-x86_64/Core --------------------------------------------
+       aml/0.1.0         (D)    cray-mpich/8.1.16    (L,D)    ginkgo/1.4.0-rocm            kokkos/3.6.00       (D)    openmpi/4.1.3              raja/0.14.0        (D)    umpire/6.0.0-rocm
+       argobots/1.1      (D)    darshan-util/3.3.1   (D)      ginkgo/1.4.0          (D)    legion/21.03.0      (D)    papi/6.0.0.1               superlu/5.3.0      (D)    umpire/6.0.0      (D)
+       bolt/2.0          (D)    flit/2.1.0           (D)      gmp/6.2.1             (D)    libunwind/1.6.2     (D)    pdt/3.25.1          (D)    swig/4.0.2-fortran        variorum/0.4.1
+       chai/2.4.0-rocm          flux-core/0.38.0     (D)      gotcha/1.0.3          (D)    loki/0.1.7          (D)    py-jupyterhub/1.4.1        swig/4.0.2         (D)    zfp/0.5.5         (D)
+       chai/2.4.0        (D)    gasnet/2022.3.0-rocm          kokkos-kernels/3.6.00 (D)    magma/2.6.2-rocm    (D)    qthreads/1.16       (D)    sz/2.1.12          (D)
+       charliecloud/0.26        gasnet/2022.3.0      (D)      kokkos/3.6.00-rocm           mpark-variant/1.4.0 (D)    raja/0.14.0-rocm           umap/2.1.0         (D)
+
+**ParaTools Deployment: E4S 22.05 / PrgEnv-gnu w/ MVAPICH2**
+
+This deployment is built using Spack at branch `e4s-22.05`, MVAPICH2, and the following facility-provided external packages:
+
+* PrgEnv-gnu
+* gcc/11.2.0
+* ROCm 5.1.0
+
+The exact Spack environment used to build this configuration is available here:
+
+* /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/mvapich2/spack.yaml
+
+.. code-block:: console
+
+    $crusher> . . /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/mvapich2/module-use.sh
+    $crusher> module avail
+        ---------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/mvapich2/spack/share/spack/lmod/cray-sles15-x86_64/mvapich2/3.0a-tdq2ett/Core ----------------------------------
+       adios/1.13.1                 datatransferkit/3.1-rc3 (D)    hypre/2.24.0           (D)    openpmd-api/0.14.4     (D)    py-warpx/22.05-dims2           superlu-dist/7.2.0 (D)
+       adios2/2.8.0                 dyninst/12.1.0          (D)    lammps/20220107        (D)    papyrus/1.0.2          (D)    py-warpx/22.05-dims3           tasmanian/7.7-rocm
+       amrex/22.05-rocm             exaworks/0.1.0                 libquo/1.3.1           (D)    parallel-netcdf/1.12.2 (D)    py-warpx/22.05-dimsRZ   (D)    tasmanian/7.7      (D)
+       amrex/22.05           (D)    faodel/1.2108.1         (D)    mercury/2.1.0          (D)    paraview/5.10.1               slate/2021.05.02        (D)    tau/2.31.1-rocm
+       arborx/1.2-rocm              fortrilinos/2.0.0       (D)    metall/0.20            (D)    parsec/3.0.2012        (D)    slepc/3.17.1-rocm              tau/2.31.1         (D)
+       arborx/1.2            (D)    globalarrays/5.8        (D)    mfem/4.4.0-rocm               petsc/3.17.1-rocm             slepc/3.17.1            (D)    trilinos/13.0.1
+       axom/0.6.1            (D)    hdf5/1.10.7                    mfem/4.4.0             (D)    petsc/3.17.1           (D)    stc/0.9.0                      turbine/1.3.0      (D)
+       butterflypack/2.1.1   (D)    heffte/2.2.0-rocm              mpifileutils/0.11.1    (D)    precice/2.4.0          (D)    strumpack/6.3.1-rocm           unifyfs/0.9.2
+       cabana/0.4.0          (D)    heffte/2.2.0            (D)    nccmp/1.9.0.1          (D)    pumi/2.2.7             (D)    strumpack/6.3.1         (D)    veloc/1.5          (D)
+       caliper/2.7.0         (D)    hpctoolkit/2022.04.15   (D)    nco/5.0.1              (D)    py-cinemasci/1.7.0            sundials/6.2.0-rocm
+       conduit/0.8.3                hpx/1.7.1-rocm                 netlib-scalapack/2.2.0 (D)    py-libensemble/0.9.1          sundials/6.2.0          (D)
+       darshan-runtime/3.3.1 (D)    hpx/1.7.1               (D)    omega-h/9.34.1         (D)    py-petsc4py/3.17.1            superlu-dist/7.2.0-rocm
+
+    --------------------------------------------- /gpfs/alpine/csc439/world-shared/E4S/ParaTools/22.05/mvapich2/spack/share/spack/lmod/cray-sles15-x86_64/Core ---------------------------------------------
+       aml/0.1.0       (D)    charliecloud/0.26           ginkgo/1.4.0-rocm            kokkos/3.6.00       (D)    nrm/0.1.0                  raja/0.14.0-rocm          umap/2.1.0        (D)
+       archer/2.0.0           darshan-util/3.3.1   (D)    ginkgo/1.4.0          (D)    legion/21.03.0      (D)    papi/6.0.0.1               raja/0.14.0        (D)    umpire/6.0.0-rocm
+       argobots/1.1    (D)    flit/2.1.0           (D)    gmp/6.2.1             (D)    libunwind/1.6.2     (D)    pdt/3.25.1          (D)    superlu/5.3.0      (D)    umpire/6.0.0      (D)
+       bolt/2.0        (D)    flux-core/0.38.0     (D)    gotcha/1.0.3          (D)    magma/2.6.2-rocm    (D)    plasma/21.8.29             swig/4.0.2-fortran        zfp/0.5.5         (D)
+       chai/2.4.0-rocm        gasnet/2022.3.0-rocm        kokkos-kernels/3.6.00 (D)    mpark-variant/1.4.0 (D)    py-jupyterhub/1.4.1        swig/4.0.2         (D)
+       chai/2.4.0      (D)    gasnet/2022.3.0      (D)    kokkos/3.6.00-rocm           mvapich2/3.0a       (L)    qthreads/1.16       (D)    sz/2.1.12          (D)
+>>>>>>> 6d5c0ff... Update deployment.rst
+
 Perlmutter
 ----------
 
@@ -52,9 +205,6 @@ The E4S deployments can be accessed via **module**. Available E4S deployments ar
 
 
 **ParaTools Deployment: E4S 22.05**
-
-This deployment is maintained by `ParaTools <https://www.paratools.com/>`_ and may not be officially supported by facility staff.
-
 
 .. code-block:: console
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -46,6 +46,8 @@ This deployment is built using Spack at branch `e4s-22.05` and system-provided O
 Crusher
 ----------
 
+For more information on Crusher please see https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html
+
 **ParaTools Deployment: E4S 22.05 / PrgEnv-gnu**
 
 This deployment is built using Spack at branch `e4s-22.05` and the following facility-provided external packages:

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -3,6 +3,7 @@ E4S Deployments
 
 These deployments are maintained by `ParaTools <https://www.paratools.com/>`_ and may not be officially supported by facility staff.
 
+
 JLSE
 ----------
 
@@ -208,6 +209,10 @@ The E4S deployments can be accessed via **module**. Available E4S deployments ar
 
 **ParaTools Deployment: E4S 22.05**
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> 5a700c3... remove duplicate mentions of ParaTools being supporter
 .. code-block:: console
 
     $perlmutter> module use /global/cfs/cdirs/m3896/shared/modulefiles/


### PR DESCRIPTION
Update deployment documentation to include Crusher deployments of E4S 22.05.

Fixes https://github.com/E4S-Project/e4s/issues/82