### PR TITLE
disable all formats since this is causing issues with PDF build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,6 @@ sphinx:
 build:
   image: latest
 
-formats: all
-
 python:
   version: 3.7
   install:


### PR DESCRIPTION
for some reason we are getting docs build failure see https://readthedocs.org/projects/e4s/builds/19632339/ so i disabled all the formats 